### PR TITLE
fix(webview): route non http(s) schemes out of WebPageView

### DIFF
--- a/app/src/main/java/com/codelv/inventory/MainActivity.kt
+++ b/app/src/main/java/com/codelv/inventory/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.codelv.inventory
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
@@ -1681,6 +1682,25 @@ fun WebPageView(
                 ViewGroup.LayoutParams.MATCH_PARENT
             )
             setWebViewClient(object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): Boolean {
+                    val target = request?.url ?: return false
+                    val scheme = target.scheme?.lowercase()
+                    if (scheme == "http" || scheme == "https" || scheme == "about") return false
+                    return try {
+                        val intent = Intent(Intent.ACTION_VIEW, target).apply {
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        }
+                        view?.context?.startActivity(intent)
+                        true
+                    } catch (e: ActivityNotFoundException) {
+                        Log.w("webview", "No handler for $target", e)
+                        true
+                    }
+                }
+
                 // WARNING: This only appears to work for GET requests and does not block a majority of the garbage requests
                 override fun shouldInterceptRequest(
                     view: WebView,


### PR DESCRIPTION
Closes #12.

`WebPageView`'s `WebViewClient` overrides `shouldInterceptRequest`, `doUpdateVisitedHistory`, `onPageStarted` and `onPageFinished`, but not `shouldOverrideUrlLoading`. Any navigation the loaded supplier page hands the WebView (a `mailto:` on a contact link, a `tel:` on a phone number, an `intent:` from a deep link) is dispatched by the default handler instead of leaving the in-app browser for the matching system app.

### Change

Add a `shouldOverrideUrlLoading` override. Keep `http`, `https` and `about:` schemes inside the WebView, route the rest out via `Intent.ACTION_VIEW`, wrap the launch in `try/catch (ActivityNotFoundException)` so a missing handler does not crash the activity:

```kotlin
override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
    val target = request?.url ?: return false
    val scheme = target.scheme?.lowercase()
    if (scheme == "http" || scheme == "https" || scheme == "about") return false
    return try {
        val intent = Intent(Intent.ACTION_VIEW, target).apply {
            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
        }
        view?.context?.startActivity(intent)
        true
    } catch (e: ActivityNotFoundException) {
        Log.w("webview", "No handler for $target", e)
        true
    }
}
```

This sits alongside the existing `WARNING` comment on `shouldInterceptRequest`. The two hooks serve different roles (one for sub-resource requests, one for top-level navigations) so it does not replace the existing intercept logic.
